### PR TITLE
Add module argument to function

### DIFF
--- a/src/CacheVariables.jl
+++ b/src/CacheVariables.jl
@@ -83,10 +83,11 @@ macro cache(path, ex::Expr, overwrite = false)
 end
 
 """
-    cache(f, path)
+    cache(f, path; mod = @__MODULE__)
 
 Cache output from running `f()` using BSON file at `path`.
 Load if the file exists; run and save if it does not.
+Use `mod` keyword argument to specify module.
 
 Tip: Use `do...end` to cache output from a block of code.
 
@@ -109,7 +110,7 @@ julia> cache("test.bson") do
 (a = "a very time-consuming quantity to compute", b = "a very long simulation to run")
 ```
 """
-function cache(@nospecialize(f), path)
+function cache(@nospecialize(f), path; mod = @__MODULE__)
     if !ispath(path)
         ans = f()
         @info(string("Saving to ", path, "\n"))
@@ -118,7 +119,7 @@ function cache(@nospecialize(f), path)
         return ans
     else
         @info(string("Loading from ", path, "\n"))
-        data = BSON.load(path, @__MODULE__)
+        data = BSON.load(path, mod)
         return data[:ans]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,5 +217,35 @@ end
     @test out == (; x = [1, 2, 3], y = 4, z = "test")
 end
 
+module MyFuncModule
+using CacheVariables, Test, DataFrames
+
+@testset "Function form - in module" begin
+    # 0. module test path
+    dirpath = joinpath(@__DIR__, "data")
+    modpath = joinpath(dirpath, "funcmodtest.bson")
+
+    # 1a. save
+    out = cache(modpath; mod = @__MODULE__) do
+        DataFrame(a = 1:10, b = 'a':'j')
+    end
+
+    # 1b. check: did variables enter workspace correctly?
+    @test out == DataFrame(a = 1:10, b = 'a':'j')
+
+    # 2. set all variables to nothing
+    out = nothing
+
+    # 3a. load
+    out = cache(modpath; mod = @__MODULE__) do
+        DataFrame(a = 1:10, b = 'a':'j')
+    end
+
+    # 3b. check: did variables enter workspace correctly?
+    @test out == DataFrame(a = 1:10, b = 'a':'j')
+end
+
+end
+
 ## Clean up
 rm(dirpath; recursive = true)


### PR DESCRIPTION
Allows us to pass in `@__MODULE__` so that the function works inside a module (e.g., when using Pluto).

Might consider adding a macro in the future to handle this, similar to the suggestion here: https://discourse.julialang.org/t/get-the-name-of-the-invoking-module/22685/6